### PR TITLE
Add commit hash to releases

### DIFF
--- a/heroku/heroku.go
+++ b/heroku/heroku.go
@@ -10,19 +10,19 @@ import (
 	"github.com/nelsam/hkslugdeploy/curl"
 )
 
-func StartRelease(app string, procs map[string]string, email string, key string, build string) chan bool {
+func StartRelease(app string, procs map[string]string, email string, key string, build string, commitish string) chan bool {
 	done := make(chan bool)
 	go func() {
-		Release(app, procs, email, key, build)
+		Release(app, procs, email, key, build, commitish)
 		done <- true
 	}()
 	return done
 }
 
-func Release(app string, procs map[string]string, email string, key string, build string) {
+func Release(app string, procs map[string]string, email string, key string, build string, commitish string) {
 	client := &heroku.Client{Username: email, Password: key}
 	log.Print("[heroku] Creating release slug")
-	slug, err := client.SlugCreate(app, procs, nil)
+	slug, err := client.SlugCreate(app, procs, &heroku.SlugCreateOpts{Commit: &commitish})
 	if err != nil {
 		log.Fatalf("[heroku][error] %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 	}
 	if herokuApp != "" {
-		done := heroku.StartRelease(herokuApp, map[string]string{"web": herokuWebProc}, herokuEmail, herokuKey, tarName)
+		done := heroku.StartRelease(herokuApp, map[string]string{"web": herokuWebProc}, herokuEmail, herokuKey, tarName, gitCommitish)
 		if sequential {
 			<-done
 		} else {


### PR DESCRIPTION
Fix #1 

Fixes the issue where `head` and `head_long` were missing by sending the commit hash to the server.
